### PR TITLE
Don't preventDefault in touchstart handler

### DIFF
--- a/addon/components/ember-virtual-scrollable.js
+++ b/addon/components/ember-virtual-scrollable.js
@@ -17,7 +17,6 @@ if (hasTouch) {
     }
     bindWindow(this.scrollerEventHandlers);
     this.doTouchStart(e.touches, e.timeStamp);
-    e.preventDefault();
   };
   moveEvent = 'touchmove';
   handleMove = function (e) {


### PR DESCRIPTION
on Android, click events in some places would never fire because of this
